### PR TITLE
Make QualityAnalyzer work as an composer dependency

### DIFF
--- a/bin/analyze
+++ b/bin/analyze
@@ -3,7 +3,21 @@
 
 namespace Qafoo\Analyzer;
 
-require __DIR__ . '/../vendor/autoload.php';
+function includeIfExists($file)
+{
+    if (file_exists($file)) {
+        return include $file;
+    }
+}
+
+if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
+    fwrite(STDERR,
+        'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+        'php composer.phar install'.PHP_EOL
+    );
+    exit(1);
+}
 
 $application = new Application();
 $application->run();

--- a/bin/analyze
+++ b/bin/analyze
@@ -3,21 +3,13 @@
 
 namespace Qafoo\Analyzer;
 
-function includeIfExists($file)
-{
-    if (file_exists($file)) {
-        return include $file;
-    }
+if (file_exists(__DIR__.'/../vendor/autoload.php')) {
+    define('VENDOR_PATH', realpath(__DIR__.'/../vendor'));
+} elseif (file_exists(__DIR__.'/../../../autoload.php')) {
+    define('VENDOR_PATH', realpath(__DIR__.'/../../..'));
 }
 
-if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
-    fwrite(STDERR,
-        'You must set up the project dependencies, run the following commands:'.PHP_EOL.
-        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
-        'php composer.phar install'.PHP_EOL
-    );
-    exit(1);
-}
+require VENDOR_PATH . '/autoload.php';
 
 $application = new Application();
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,6 @@
         "psr-0": {
             "Qafoo": ["src/php", "test/php"]
         }
-    }
+    },
+    "bin": ["bin/analyze"]
 }

--- a/src/php/Qafoo/Analyzer/Application.php
+++ b/src/php/Qafoo/Analyzer/Application.php
@@ -16,7 +16,8 @@ class Application extends Console\Application
      */
     protected function getDefaultCommands()
     {
-        $shell = new Shell(__DIR__ . '/../../../../');
+
+        $shell = new Shell(dirname(VENDOR_PATH));
 
         return array_merge(
             parent::getDefaultCommands(),


### PR DESCRIPTION
Usage:

```
require-dev: {
    "qafoo/quality-analyzer": "dev-master"
},
repositories: [
  {
    "type": "vcs",
    "url": "https://github.com/Qafoo/QualityAnalyzer"
  }
]
```

Run composer:
```
composer update
```

And now you can run it inside your project with:
```
vendor/bin/analyze ...
```