### PR TITLE
Allow setting the hostname via a --hostname flag

### DIFF
--- a/src/php/Qafoo/Analyzer/Command/Serve.php
+++ b/src/php/Qafoo/Analyzer/Command/Serve.php
@@ -21,14 +21,22 @@ class Serve extends Command
                 InputOption::VALUE_REQUIRED,
                 'Port to start webserver on',
                 8080
+            )
+            ->addOption(
+                'hostname',
+                null, // -h is already used for help
+                InputOption::VALUE_REQUIRED,
+                'Hostname used to listen to',
+                'localhost'
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $port = (int) $input->getOption('port');
+        $hostname = $input->getOption('hostname');
         $baseDir = realpath(__DIR__ . '/../../../../../');
-        $output->writeln("Starting webserver on http://localhost:$port/");
-        passthru("/usr/bin/env php -S localhost:$port -t $baseDir $baseDir/bin/serve.php");
+        $output->writeln("Starting webserver on http://$hostname:$port/");
+        passthru("/usr/bin/env php -S $hostname:$port -t $baseDir $baseDir/bin/serve.php");
     }
 }


### PR DESCRIPTION
This should make it possible to use the app from i.e. inside a (docker) container for easy running...

``` docker run -it --rm -v $(pwd):/app -w /app -p 80:8080 php:7-cli bin/analyze serve --hostname 0.0.0.0 ```