### PR TITLE
Use optional parameter

### DIFF
--- a/src/php/Qafoo/Analyzer/Shell.php
+++ b/src/php/Qafoo/Analyzer/Shell.php
@@ -65,8 +65,8 @@ class Shell
      * @param string $prefix
      * @return string
      */
-    public function getTempFile($prefix = 'qas')
+    public function getTempFile($prefix = 'qa')
     {
-        return tempnam(sys_get_temp_dir(), 'qa');
+        return tempnam(sys_get_temp_dir(), $prefix);
     }
 }


### PR DESCRIPTION
Presumably it was intended to work this way.
No behaviour change for the case where no value is provided.