### PR TITLE
List and exclude handlers on analyze

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,21 @@ After the analyzer has finished use ``bin/analyze serve`` or similar means to
 access the ``index.html`` with your browser and enjoy the results
 visualization.
 
+Exclude Analyzers
+-----------------
+
+You might also to avoid some analyzers to be run on your code intentionally, e.g.
+if you don't want your git usage be analysed. For this you may use the
+``--exclude_analyzers`` option::
+
+    bin/analyze \
+        --exclude_analyzers=git,gitDetailed \
+        analyze /path/to/source
+
+To get a list of all available analyzers, run::
+
+    bin/analyze list:analyzers
+
 Customize Tools
 ---------------
 

--- a/src/php/Qafoo/Analyzer/Application.php
+++ b/src/php/Qafoo/Analyzer/Application.php
@@ -19,27 +19,28 @@ class Application extends Console\Application
 
         $shell = new Shell(dirname(VENDOR_PATH));
 
+        $handlers = [
+          'source'       => new Handler\Source($shell),
+          'coverage'     => new Handler\Coverage(),
+          'pdepend'      => new Handler\PDepend($shell),
+          'dependencies' => new Handler\Dependencies($shell),
+          'phpmd'        => new Handler\PHPMD($shell),
+          'checkstyle'   => new Handler\Checkstyle($shell),
+          'tests'        => new Handler\Tests(),
+          'cpd'          => new Handler\CPD($shell),
+          'phploc'       => new Handler\Phploc($shell),
+          'git'          => new Handler\Git($shell),
+          'gitDetailed'  => new Handler\GitDetailed($shell),
+        ];
+
         return array_merge(
-            parent::getDefaultCommands(),
-            array(
-                new Command\Serve(),
-                new Command\Bundle(),
-                new Command\Analyze(
-                    array(
-                        'source' => new Handler\Source($shell),
-                        'coverage' => new Handler\Coverage(),
-                        'pdepend' => new Handler\PDepend($shell),
-                        'dependencies' => new Handler\Dependencies($shell),
-                        'phpmd' => new Handler\PHPMD($shell),
-                        'checkstyle' => new Handler\Checkstyle($shell),
-                        'tests' => new Handler\Tests(),
-                        'cpd' => new Handler\CPD($shell),
-                        'phploc' => new Handler\Phploc($shell),
-                        'git' => new Handler\Git($shell),
-                        'gitDetailed' => new Handler\GitDetailed($shell),
-                    )
-                ),
-            )
+          parent::getDefaultCommands(),
+          [
+            new Command\Serve(),
+            new Command\Bundle(),
+            new Command\Analyze($handlers),
+            new Command\Analyzers($handlers),
+          ]
         );
     }
 }

--- a/src/php/Qafoo/Analyzer/Command/Analyze.php
+++ b/src/php/Qafoo/Analyzer/Command/Analyze.php
@@ -4,104 +4,128 @@ namespace Qafoo\Analyzer\Command;
 
 use Qafoo\Analyzer\Handler;
 use Qafoo\Analyzer\Project;
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use Qafoo\Analyzer\Handler\RequiresCoverage;
-
 class Analyze extends Command
 {
+    const ARGUMENT_PATH            = 'path';
+    const NAME                     = 'analyze';
+    const OPTION_COVERAGE          = 'coverage';
+    const OPTION_EXCLUDE_ANALYZERS = 'exclude_analyzers';
+    const OPTION_PDEPEND           = 'pdepend';
+    const OPTION_DEPENDENCIES      = 'dependencies';
+    const OPTION_PHPMD             = 'phpmd';
+    const OPTION_CHECKSTYLE        = 'checkstyle';
+    const OPTION_TESTS             = 'tests';
+    const OPTION_CPD               = 'cpd';
+    const OPTION_PHPLOC            = 'phploc';
+    const OPTION_EXCLUDE           = 'exclude';
+    const ALIAS_COVERAGE           = 'c';
+    const ALIAS_TESTS              = 't';
+    const ALIAS_EXCLUDE            = 'x';
+
     /**
      * Handlers
      *
      * @var Handler[]
      */
-    private $handlers = array();
+    private $handlers = [];
 
-    public function __construct(array $handlers = array(), $targetDir = null)
+    /** @var string */
+    private $targetDir;
+
+    public function __construct(array $handlers = [], $targetDir = null)
     {
         parent::__construct();
 
-        $this->handlers = $handlers;
+        $this->handlers  = $handlers;
         $this->targetDir = $targetDir ?: __DIR__ . '/../../../../../data/';
     }
 
     protected function configure()
     {
         $this
-            ->setName('analyze')
-            ->setDescription('Analyze PHP code')
-            ->addArgument(
-                'path',
-                InputArgument::REQUIRED,
-                'Path to the source code which should be analyzed'
-            )->addOption(
-                'coverage',
-                'c',
-                InputOption::VALUE_REQUIRED,
-                'Path to code coverage (clover) XML file'
-            )->addOption(
-                'pdepend',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Path to PDepend summary XML file'
-            )->addOption(
-                'dependencies',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Path to PDepend dependencies XML file'
-            )->addOption(
-                'phpmd',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Path to mess detector (PMD / PHPMD) XML file'
-            )->addOption(
-                'checkstyle',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Path to checkstyle violations (PHP Code Sniffer) XML file'
-            )->addOption(
-                'tests',
-                't',
-                InputOption::VALUE_REQUIRED,
-                'Path to jUnit (PHPUnit) test result XML file'
-            )->addOption(
-                'cpd',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Path to C&P violations (PHP Copy Paste Detector) XML file'
-            )->addOption(
-                'phploc',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Path to PHPLoc result XML file'
-            )->addOption(
-                'exclude',
-                'x',
-                InputOption::VALUE_REQUIRED,
-                'Directories to exclude from analyzing'
-            );
+          ->setName(self::NAME)
+          ->setDescription('Analyze PHP code')
+          ->addArgument(
+            self::ARGUMENT_PATH,
+            InputArgument::REQUIRED,
+            'Path to the source code which should be analyzed'
+          )->addOption(
+            self::OPTION_COVERAGE,
+            self::ALIAS_COVERAGE,
+            InputOption::VALUE_REQUIRED,
+            'Path to code coverage (clover) XML file'
+          )->addOption(
+            self::OPTION_PDEPEND,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to PDepend summary XML file'
+          )->addOption(
+            self::OPTION_DEPENDENCIES,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to PDepend dependencies XML file'
+          )->addOption(
+            self::OPTION_PHPMD,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to mess detector (PMD / PHPMD) XML file'
+          )->addOption(
+            self::OPTION_CHECKSTYLE,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to checkstyle violations (PHP Code Sniffer) XML file'
+          )->addOption(
+            self::OPTION_TESTS,
+            self::ALIAS_TESTS,
+            InputOption::VALUE_REQUIRED,
+            'Path to jUnit (PHPUnit) test result XML file'
+          )->addOption(
+            self::OPTION_CPD,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to C&P violations (PHP Copy Paste Detector) XML file'
+          )->addOption(
+            self::OPTION_PHPLOC,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to PHPLoc result XML file'
+          )->addOption(
+            self::OPTION_EXCLUDE,
+            self::ALIAS_EXCLUDE,
+            InputOption::VALUE_REQUIRED,
+            'Directories to exclude from analyzing'
+          )->addOption(
+            self::OPTION_EXCLUDE_ANALYZERS,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Analyzers to exclude from analyzing as comma separated list, e.g. "git,gitDetailed"'
+          )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $exclude = array_filter(array_map('trim', explode(',', $input->getOption('exclude'))));
+        $exclude = array_filter(array_map('trim', explode(',', $input->getOption(self::OPTION_EXCLUDE))));
 
-        if (!is_dir($path = realpath($input->getArgument('path')))) {
-            throw new \OutOfBoundsException("Could not find " . $input->getArgument('path'));
+        if (!is_dir($path = realpath($input->getArgument(self::ARGUMENT_PATH)))) {
+            throw new \OutOfBoundsException("Could not find " . $input->getArgument(self::ARGUMENT_PATH));
         }
         $output->writeln("Analyze source code in $path");
 
-        $project = new Project();
+        $project          = new Project();
         $project->dataDir = $this->targetDir;
         $project->baseDir = $path;
-        if ($input->hasOption('coverage')) {
-            $project->coverage = $input->getOption('coverage');
+        if ($input->hasOption(self::OPTION_COVERAGE)) {
+            $project->coverage = $input->getOption(self::OPTION_COVERAGE);
         }
+
+        $this->filterHandlers($input);
 
         foreach ($this->handlers as $name => $handler) {
             $output->writeln(" * Running $name");
@@ -122,12 +146,23 @@ class Analyze extends Command
         $output->writeln("Done");
     }
 
+    private function filterHandlers(InputInterface $input)
+    {
+        if ($excludeHandlers = $input->getOption(self::OPTION_EXCLUDE_ANALYZERS)) {
+            $excludeHandlers = array_map('trim', explode(',', $excludeHandlers));
+            $excludeHandlers = array_combine($excludeHandlers, $excludeHandlers);
+            $this->handlers  = array_diff_key($this->handlers, $excludeHandlers);
+        }
+    }
+
     /**
      * Copy result file
      *
      * @param string $handler
      * @param string $file
+     *
      * @return string
+     * @throws \OutOfBoundsException
      */
     protected function copyResultFile($handler, $file)
     {
@@ -141,6 +176,7 @@ class Analyze extends Command
         }
 
         copy($file, $this->targetDir . '/' . $handler . '.' . $extension);
+
         return "$handler.$extension";
     }
 }

--- a/src/php/Qafoo/Analyzer/Command/Analyzers.php
+++ b/src/php/Qafoo/Analyzer/Command/Analyzers.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Qafoo\Analyzer\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class Handlers
+ *
+ * @package Qafoo\Analyzer\Command
+ */
+class Analyzers extends Command
+{
+    const DESCRIPTION = 'Lists all available analyzers';
+
+    const HELP        = 'Lists all available analyzers enabled by default';
+
+    const NAME        = 'list:analyzers';
+
+    /**
+     * @var array
+     */
+    private $analysers;
+
+    public function __construct(array $analysers)
+    {
+        parent::__construct(self::NAME);
+        $this->analysers = $analysers;
+    }
+
+    protected function configure()
+    {
+        $this
+          ->setDescription(self::DESCRIPTION)
+          ->setHelp(self::HELP)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>The following analysers are available and enabled by default:</info>');
+        foreach (array_keys($this->analysers) as $analyser) {
+            $output->writeln('- ' . $analyser);
+        }
+    }
+}

--- a/test/php/Qafoo/Analyzer/Command/AnalyzeTest.php
+++ b/test/php/Qafoo/Analyzer/Command/AnalyzeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Qafoo\Analyzer\Command;
+
+use Qafoo\Analyzer\Handler;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class AnalyzeTest
+ *
+ * @package Qafoo\Analyzer\Command
+ */
+class AnalyzeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function excludeHandlers()
+    {
+        $coverageHandler = $this->buildMock(Handler\Coverage::class);
+        $testsHandler    = $this->buildMock(Handler\Tests::class);
+        $handlers        = [
+          'coverage' => $coverageHandler,
+          'tests'    => $testsHandler,
+          'foo'      => $testsHandler,
+        ];
+
+        $coverageHandler->expects(self::once())
+                        ->method('handle')
+                        ->willReturn('success')
+        ;
+
+        $testsHandler->expects(self::never())
+                     ->method('handle')
+        ;
+
+        $app = new Application();
+        $app->add(new Analyze($handlers));
+
+        $command = $app->find(Analyze::NAME);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+          [
+            'command'             => $command->getName(),
+            'path'                => __DIR__,
+            '--exclude_analyzers' => 'tests,foo',
+          ]
+        );
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function buildMock($className)
+    {
+        return $this->getMockBuilder($className)->disableOriginalConstructor()->getMock();
+    }
+}

--- a/test/php/Qafoo/Analyzer/Command/AnalyzersTest.php
+++ b/test/php/Qafoo/Analyzer/Command/AnalyzersTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Qafoo\Analyzer\Command;
+
+use Qafoo\Analyzer\Handler;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class Handlers
+ *
+ * @package Qafoo\Analyzer\Command
+ */
+class AnalyzersTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function getName()
+    {
+        self::assertEquals(Analyzers::NAME, (new Analyzers([]))->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function getDescription()
+    {
+        self::assertEquals(Analyzers::DESCRIPTION, (new Analyzers([]))->getDescription());
+    }
+
+    /**
+     * @test
+     */
+    public function getHelp()
+    {
+        self::assertEquals(Analyzers::HELP, (new Analyzers([]))->getHelp());
+    }
+
+    /**
+     * @test
+     */
+    public function commandListsAllHandlerKeys()
+    {
+        $handlers = [
+          'coverage' => new Handler\Coverage(),
+          'tests'    => new Handler\Tests(),
+        ];
+
+        $app = new Application();
+        $app->add(new Analyzers($handlers));
+
+        $command       = $app->find(Analyzers::NAME);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+          'command' => $command->getName(),
+        ]);
+
+        $output = <<<'MSG'
+The following analysers are available and enabled by default:
+- coverage
+- tests
+
+MSG;
+        self::assertEquals($output, $commandTester->getDisplay(true));
+    }
+}

--- a/test/php/Qafoo/Analyzer/Command/AnalyzersTest.php
+++ b/test/php/Qafoo/Analyzer/Command/AnalyzersTest.php
@@ -16,7 +16,7 @@ class AnalyzersTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function getName()
+    public function getCommandName()
     {
         self::assertEquals(Analyzers::NAME, (new Analyzers([]))->getName());
     }


### PR DESCRIPTION
As we have a very large git history, we needed to skip some of the handlers, so I came up with the idea for this PR.

To figure out, which handlers are available, as a user, I also added the `list:analyzers` command.

Also did some simple code refactorings.